### PR TITLE
Implement a new command for Tinlake reward claims transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # Welcome to Centrifuge Commander
 
-With Centrifuge `Commander`, you have the overall Centrifuge ecosystem at your fingertips. It is an intuitive and easy to use command-line interface (CLI) that help you land and work efficiently with Centrifuge chain and dapps.
+With Centrifuge `Commander`, you have the overall Centrifuge ecosystem at your fingertips. Among others, it provides with a local development sandbox for Rust, a command for bootstraping a local Centrifuge network, with a relay chain and one or more parachains, and more. It is an intuitive and easy to use command-line interface (CLI) that help you land and work efficiently with Centrifuge chain and dapps.
 
-...
+## Building Centrifuge Commander
+
+Building Centrifuge Commander is simple:
+
+```sh
+$ yarn
+$ yarn run build
+```
+
+## Run Commander locally
+
+```sh
+$ ./packages/application/bin/run.js --help
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "centrifuge-cli",
-  "version": "1.0.0",
+  "name": "centrifuge-commander",
+  "version": "0.1.0",
   "description": "",
   "main": "index.js",
   "private": true,
@@ -21,15 +21,20 @@
     "release": "lerna version",
     "prerelease": "lerna version prerelease --preid next"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+      "centrifuge",
+      "cli",
+      "commander",
+      "console"
+  ],
+  "author": "Centrifuge Contributors",
+  "license": "Apache-2.0",
 
   "devDependencies": {
     "@typescript-eslint/parser": "^5.4.0",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@types/prettier": "^2.4.0",
-    "@types/node": "^16.11.11",
+    "@types/node": "^17.0.0",
     "eslint": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-config-prettier": "^8.3.0",
@@ -41,7 +46,7 @@
     "lerna": "^4.0.0",
     "prettier": "^2.5.0",
     "rimraf": "^3.0.2",
-    "typescript": "^4.5.2"
+    "typescript": "^4.5.5"
   },
 
   "husky": {

--- a/packages/application/README.md
+++ b/packages/application/README.md
@@ -1,11 +1,8 @@
-# `core`
+# Centrifuge Commander Application Module
 
-> TODO: description
+This module is the Centrifuge Commander's main module.
 
+...
 ## Usage
 
-```
-const core = require('core');
-
-// TODO: DEMONSTRATE API
-```
+...

--- a/packages/application/bin/run.js
+++ b/packages/application/bin/run.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node --experimental-json-modules
 
-import { Application } from '@centrifuge-cli/application';
+import { Application } from '@centrifuge-commander/application';
 
 await new Application().run();

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -1,14 +1,16 @@
 {
-    "name": "@centrifuge-cli/application",
+    "name": "@centrifuge-commander/application",
     "description": "Centrifuge ecosystem at your finger tips",
     "version": "0.1.1",
     "author": "Centrifuge Foundation <hello@centrifuge.io>",
-    "homepage": "https://github.com/centrifuge/centrifuge-cli#README.md",
-    "bugs": {"url": "https://github.com/centrifuge/centrifuge-cli/issues"},
+    "homepage": "https://github.com/centrifuge/commander#README.md",
+    "bugs": {"url": "https://github.com/centrifuge/commander/issues"},
     "license": "Apache-2.0",
     "keywords": [
       "centrifuge",
-      "centrifuge-cli",
+      "cli",
+      "commander",
+      "console,",
       "application"
     ],
     "type": "module",
@@ -29,7 +31,7 @@
     "repository": {
       "type": "git",
       "directory": "packages/libraries/core",
-      "url": "https://github.com/centrifuge/centrifuge-cli.git"
+      "url": "https://github.com/centrifuge/commander.git"
     },
     "engines": {
       "node": ">=14.17.4"
@@ -49,17 +51,18 @@
     },
     
     "dependencies": {
-      "@centrifuge-cli/core": "^0.1.0",
-      "@centrifuge-cli/chain-command": "^0.1.0",
-      "@centrifuge-cli/setup-command": "^0.1.0",
-      "@centrifuge-cli/crowdloan-command": "^0.1.0",
+      "@centrifuge-commander/core": "^0.1.0",
+      "@centrifuge-commander/chain-command": "^0.1.0",
+      "@centrifuge-commander/claims-command": "^0.1.0",
+      "@centrifuge-commander/setup-command": "^0.1.0",
+      "@centrifuge-commander/crowdloan-command": "^0.1.0",
       "cli-progress-footer": "^2.3.0",
-      "cli-ux": "^5.6.0",
-      "commander": "^8.3.0",
+      "cli-ux": "^6.0.0",
+      "commander": "^9.0.0",
       "inquirer": "^8.2.0"
     },
 
     "devDependencies": {
-      "@types/inquirer": "^8.1.3"
+      "@types/inquirer": "^8.2.0"
     }
 }

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -2,7 +2,7 @@
     "name": "@centrifuge-commander/application",
     "description": "Centrifuge ecosystem at your finger tips",
     "version": "0.1.1",
-    "author": "Centrifuge Foundation <hello@centrifuge.io>",
+    "author": "Centrifuge Contributors <hello@centrifuge.io>",
     "homepage": "https://github.com/centrifuge/commander#README.md",
     "bugs": {"url": "https://github.com/centrifuge/commander/issues"},
     "license": "Apache-2.0",

--- a/packages/application/src/application.ts
+++ b/packages/application/src/application.ts
@@ -4,10 +4,11 @@
  * @module
  */
 
-import { BaseCommand } from '@centrifuge-cli/core/command';
-import { ChainCommand } from '@centrifuge-cli/chain-command/command';
-import { SetupCommand } from '@centrifuge-cli/setup-command/command';
-import colors from '@centrifuge-cli/core/colors';
+import { BaseCommand } from '@centrifuge-commander/core/command';
+import { ChainCommand } from '@centrifuge-commander/chain-command/command';
+import { ClaimsCommand } from '@centrifuge-commander/claims-command/command';
+import { SetupCommand } from '@centrifuge-commander/setup-command/command';
+import colors from '@centrifuge-commander/core/colors';
 import { existsSync, mkdirSync } from 'fs';
 import { homedir } from 'os';
 import { join, normalize } from 'path';
@@ -20,7 +21,7 @@ import { join, normalize } from 'path';
  * Script Module (or ESM) standard (see 'bin/run.js' script, for instance).
  * The 'assert' directive is mandatory (as explained in https://nodejs.org/api/esm.html#import-assertions).
  */
-import packageInfo from '@centrifuge-cli/application/package.json' assert { type: 'json' };
+//import packageInfo from '@centrifuge-commander/application/package.json' assert { type: 'json' };
 
 /**
  * Application's main command.
@@ -30,7 +31,7 @@ import packageInfo from '@centrifuge-cli/application/package.json' assert { type
  *
  * ## Example
  * ```typescript
- * import { Application } from '@centrifuge-cli/application';
+ * import { Application } from '@centrifuge-commander/application';
  *
  *  await new Application().run();
  * ```
@@ -74,10 +75,12 @@ Use ${colors.command('centrifuge [command] --help')} for more information on a c
    */
   protected initialize(): void {
     this.name(Application.Name)
-      .version(packageInfo.version)
+//      .version(packageInfo.version)
+      .version("0.1.0")
       .description(Application.Description)
       .addHelpText('after', Application.Help)
       .addCommand(new ChainCommand())
+      .addCommand(new ClaimsCommand())
       .addCommand(new SetupCommand());
   }
 
@@ -88,7 +91,7 @@ Use ${colors.command('centrifuge [command] --help')} for more information on a c
    *
    * @example:
    * ```typescript
-   * import { Application } from '@centrifuge-cli/application';
+   * import { Application } from '@centrifuge-commander/application';
    *
    * await new Application().run();
    * ```

--- a/packages/application/src/wizards/cloud.ts
+++ b/packages/application/src/wizards/cloud.ts
@@ -1,7 +1,7 @@
 import inquirer, { ListQuestion, PasswordQuestion } from 'inquirer';
 import { WelcomeWizardData } from './welcome';
-import { AWSCloudProvider, AWSCloudProviderErrors } from '@centrifuge-cli/core/cloud/aws.js';
-import { Obfuscator } from '@centrifuge-cli/core/obfuscator';
+import { AWSCloudProvider, AWSCloudProviderErrors } from '@centrifuge-commander/core/cloud/aws.js';
+import { Obfuscator } from '@centrifuge-commander/core/obfuscator';
 
 /**
  * Data gathered by AWS configuration wizard.

--- a/packages/application/src/wizards/welcome.ts
+++ b/packages/application/src/wizards/welcome.ts
@@ -1,7 +1,7 @@
 import inquirer, { ConfirmQuestion, ListQuestion } from 'inquirer';
 //import { Application } from '../application.js';
 import { CloudProviderType, LanguageType } from '../types.js';
-import { colors } from '@centrifuge-cli/core/colors';
+import { colors } from '@centrifuge-commander/core/colors';
 import { AWSConfigurationWizard } from './cloud.js';
 
 /* basic preferences data */

--- a/packages/commands/chain/README.md
+++ b/packages/commands/chain/README.md
@@ -1,13 +1,14 @@
-# Centrifuge CLI `chain` Command
+# Centrifuge Commander Chain Command
 
-> TODO: description
+## Overview
 
+This command helps managing a local and remote (cloud-based) sandbox (or Centrifuge chain development environment) for developers to easily land and work with Centrifuge ecosystem.
+
+Among others this command helps setting up:
+
+- A local Docker-based containerized development environment for Rust programming language
+
+- A local Centrifuge network, made up of a local Polkadot relay chain with validator nodes and a local Centrifuge parachain with collator nodes.
+
+- More...
 ## Usage
-
-```
-import { ChainCommand } from '@centrifuge-cli/chain-command';
-
-const command = new SetupCommand();
-
-command.run();
-```

--- a/packages/commands/chain/package.json
+++ b/packages/commands/chain/package.json
@@ -1,14 +1,14 @@
 {
-    "name": "@centrifuge-cli/chain-command",
+    "name": "@centrifuge-commander/chain-command",
     "description": "Command used to manage local or remote Centrifuge network",
     "version": "0.1.0",
     "author": "Centrifuge Foundation <admin@centrifuge.io>",
-    "homepage": "https://github.com/centrifuge/centrifuge-cli#README.md",
-    "bugs": {"url": "https://github.com/centrifuge/centrifuge-cli/issues"},
+    "homepage": "https://github.com/centrifuge/centrifuge-commander#README.md",
+    "bugs": {"url": "https://github.com/centrifuge/centrifuge-commander/issues"},
     "license": "Apache-2.0",
     "keywords": [
       "centrifuge",
-      "centrifuge-cli",
+      "centrifuge-commander",
       "chain-command"
     ],
     "type": "module",
@@ -27,7 +27,7 @@
     "repository": {
       "type": "git",
       "directory": "packages/commands/chain",
-      "url": "https://github.com/centrifuge/centrifuge-cli.git"
+      "url": "https://github.com/centrifuge/centrifuge-commander.git"
     },
     "engines": {
       "node": ">=14.17.4"
@@ -47,7 +47,7 @@
     },
 
     "dependencies": {
-      "@centrifuge-cli/core": "^0.1.0",
+      "@centrifuge-commander/core": "^0.1.0",
       "cli-ux": "^5.6.0",
       "commander": "^8.3.0"
     }

--- a/packages/commands/chain/package.json
+++ b/packages/commands/chain/package.json
@@ -2,7 +2,7 @@
     "name": "@centrifuge-commander/chain-command",
     "description": "Command used to manage local or remote Centrifuge network",
     "version": "0.1.0",
-    "author": "Centrifuge Foundation <admin@centrifuge.io>",
+    "author": "Centrifuge Contributors <hello@centrifuge.io>",
     "homepage": "https://github.com/centrifuge/centrifuge-commander#README.md",
     "bugs": {"url": "https://github.com/centrifuge/centrifuge-commander/issues"},
     "license": "Apache-2.0",
@@ -41,9 +41,7 @@
       "pretest": "tsc -p test --noEmit",
       "posttest": "yarn lint",
       "test": "nyc --extension .ts mocha --forbid-only test/**/*.test.ts",
-      "prepack": "yarn build",
-      "postpack": "rm -f oclif.manifest.json",
-      "version": "oclif-dev readme && git add README.md"    
+      "prepack": "yarn build"
     },
 
     "dependencies": {

--- a/packages/commands/chain/src/actions/create.ts
+++ b/packages/commands/chain/src/actions/create.ts
@@ -1,5 +1,5 @@
-import { BaseCommand } from '@centrifuge-cli/core/command';
-//import colors from '@centrifuge-cli/core/colors.js';
+import { BaseCommand } from '@centrifuge-commander/core/command';
+//import colors from '@centrifuge-commander/core/colors.js';
 //import { cli } from 'cli-ux';
 
 /*

--- a/packages/commands/chain/src/actions/start.ts
+++ b/packages/commands/chain/src/actions/start.ts
@@ -1,5 +1,5 @@
-import { BaseCommand } from '@centrifuge-cli/core/command';
-//import colors from '@centrifuge-cli/core/colors.js';
+import { BaseCommand } from '@centrifuge-commander/core/command';
+//import colors from '@centrifuge-commander/core/colors.js';
 //import { cli } from 'cli-ux';
 
 /*

--- a/packages/commands/chain/src/command.ts
+++ b/packages/commands/chain/src/command.ts
@@ -1,4 +1,4 @@
-import { BaseCommand } from '@centrifuge-cli/core/command';
+import { BaseCommand } from '@centrifuge-commander/core/command';
 import { ChainCreateCommand } from './actions/create.js';
 import { ChainStartCommand } from './actions/start.js';
 

--- a/packages/commands/claims/.eslintignore
+++ b/packages/commands/claims/.eslintignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/packages/commands/claims/.eslintrc.json
+++ b/packages/commands/claims/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+    "extends": [
+      "eslint:recommended",
+      "plugin:@typescript-eslint/recommended",
+      "plugin:@typescript-eslint/recommended-requiring-type-checking"
+    ],
+    "rules": {
+    }
+}

--- a/packages/commands/claims/README.md
+++ b/packages/commands/claims/README.md
@@ -1,0 +1,13 @@
+# Centrifuge CLI `chain` Command
+
+> TODO: description
+
+## Usage
+
+```
+import { ChainCommand } from '@centrifuge-commander/chain-command';
+
+const command = new SetupCommand();
+
+command.run();
+```

--- a/packages/commands/claims/package.json
+++ b/packages/commands/claims/package.json
@@ -1,22 +1,26 @@
 {
-    "name": "@centrifuge-commander/crowdloan-command",
-    "description": "Command used to manage Polkadot/Kusama crowdloan auctions for parachain slot acquisition or renewal",
+    "name": "@centrifuge-commander/claims-command",
+    "description": "Command used to migrate Tinlake reward claims from standalone Centrifuge chain to a parachain (e.g. Altair)",
     "version": "0.1.0",
-    "author": "Centrifuge Foundation <admin@centrifuge.io>",
-    "homepage": "https://github.com/centrifuge/centrifuge-commander#README.md",
-    "bugs": {"url": "https://github.com/centrifuge/centrifuge-commander/issues"},
+    "author": "Centrifuge Foundation <hello@centrifuge.io>",
+    "homepage": "https://github.com/centrifuge/commander#README.md",
+    "bugs": {"url": "https://github.com/centrifuge/commander/issues"},
     "license": "Apache-2.0",
     "keywords": [
       "centrifuge",
-      "centrifuge-commander",
-      "chain-command"
+      "cli",
+      "commander",
+      "console",
+      "claims",
+      "rewards"
     ],
     "type": "module",
-    "main": "dist/index.js",
+    "main": "dist/command.js",
     "exports": {
-        ".": "./dist/index.js",
-        "./*": "./dist/*",
-        "./package.json": "./package.json"
+        ".": "./dist/command.js",
+        "./command": "./dist/command.js",
+        "./actions/*": null,
+        "./package.json": "./dist/package.json"
     },
     "typesVersions": {
         "*": { 
@@ -25,8 +29,8 @@
     },
     "repository": {
       "type": "git",
-      "directory": "packages/commands/crowdloan",
-      "url": "https://github.com/centrifuge/centrifuge-commander.git"
+      "directory": "packages/commands/claims",
+      "url": "https://github.com/centrifuge/commander.git"
     },
     "engines": {
       "node": ">=14.17.4"
@@ -34,7 +38,7 @@
     "scripts": {
       "clean": "rimraf dist node_modules tsconfig.tsbuildinfo .nyc_output",
       "compile": "tsc --build && cp ./package.json ./dist/",
-      "build": "yarn clean && yarn compile",
+      "build": "yarn compile",
       "lint": "eslint src/**/*.ts --max-warnings=0 --config .eslintrc.json --ignore-path .eslintignore",
       "lint:fix": "eslint --fix src/**/*.ts",
       "pretest": "tsc -p test --noEmit",
@@ -44,15 +48,11 @@
       "postpack": "rm -f oclif.manifest.json",
       "version": "oclif-dev readme && git add README.md"    
     },
+
     "dependencies": {
       "@centrifuge-commander/core": "^0.1.0",
-      "commander": "^8.3.0"
-    },
-
-    "devDependencies": {
-    },
-    
-    "files": [
-      "src"
-    ]
+      "@polkadot/api": "^7.7.1",
+      "cli-ux": "^5.6.0",
+      "commander": "^9.0.0"
+    }
 }

--- a/packages/commands/claims/package.json
+++ b/packages/commands/claims/package.json
@@ -2,7 +2,7 @@
     "name": "@centrifuge-commander/claims-command",
     "description": "Command used to migrate Tinlake reward claims from standalone Centrifuge chain to a parachain (e.g. Altair)",
     "version": "0.1.0",
-    "author": "Centrifuge Foundation <hello@centrifuge.io>",
+    "author": "Centrifuge Contributors <hello@centrifuge.io>",
     "homepage": "https://github.com/centrifuge/commander#README.md",
     "bugs": {"url": "https://github.com/centrifuge/commander/issues"},
     "license": "Apache-2.0",
@@ -20,6 +20,7 @@
         ".": "./dist/command.js",
         "./command": "./dist/command.js",
         "./actions/*": null,
+        "./controller": "./dist/packages/controller.js",
         "./package.json": "./dist/package.json"
     },
     "typesVersions": {
@@ -44,14 +45,13 @@
       "pretest": "tsc -p test --noEmit",
       "posttest": "yarn lint",
       "test": "nyc --extension .ts mocha --forbid-only test/**/*.test.ts",
-      "prepack": "yarn build",
-      "postpack": "rm -f oclif.manifest.json",
-      "version": "oclif-dev readme && git add README.md"    
+      "prepack": "yarn build"
     },
 
     "dependencies": {
       "@centrifuge-commander/core": "^0.1.0",
       "@polkadot/api": "^7.7.1",
+      "chalk": "^5.0.0",
       "cli-ux": "^5.6.0",
       "commander": "^9.0.0"
     }

--- a/packages/commands/claims/src/actions/migrate.ts
+++ b/packages/commands/claims/src/actions/migrate.ts
@@ -1,0 +1,65 @@
+import { BaseCommand } from '@centrifuge-commander/core/command';
+//import colors from '@centrifuge-commander/core/colors.js';
+//import { cli } from 'cli-ux';
+
+/*
+ * Migrate claims command options.
+ */
+interface MigrateClaimsCommandOptions {
+  config?: string;
+  fromUrl: string;
+  toUrl: string;
+  fromBlock: string;
+}
+
+/**
+ * Reward claims migration command class.
+ *
+ * This command is used for migrating Tinlake reward claims from the standalone Centrifuge chain
+ * to a parachain, such as, for instance, a local collator node (during testing phase) or to
+ * Altair (onboarded on Kusama testing relay chain).
+ */
+export class MigrateClaimsCommand extends BaseCommand {
+  /**
+   * Build a new subcommand instance.
+   *
+   * @param {string} name A string containing the name of the command.
+   */
+  constructor(name?: string) {
+    super(name === undefined ? 'migrate' : name);
+  }
+
+  /**
+   * Initialize command options and arguments.
+   */
+  protected initialize(): void {
+    this.description('Migrate Tinlake reward claims from Centrifuge chain to a parachain')
+      .addHelpText(
+        'after',
+        `
+  Examples:
+    $ centrifuge claims migrate --from_url --to_url --from_blockconfig ./standalone-chain.json`,
+      )
+      .action(this.execute.bind(this));
+  }
+
+  /**
+   * Handle command auto-completion.
+   */
+  protected autocomplete(): void {
+    console.log('Claims migration command does not implement auto-completion for now');
+  }
+
+  /*
+   * Handle command action.
+   *
+   * @param {string} chain Argument containing the name of the chain to be started.
+   * @param {ChainStartCommandOptions} options List of options passed at command-line.
+   */
+  private execute(fromUrl: string, toUrl: string, fromBlock: string, options: MigrateClaimsCommandOptions): void {
+    console.log(`  from URL:  ${fromUrl}`);
+    if (options.config) {
+      console.log(`  config file: ${options.config}`);
+    }
+  }
+}

--- a/packages/commands/claims/src/actions/migrate.ts
+++ b/packages/commands/claims/src/actions/migrate.ts
@@ -32,8 +32,11 @@ export class MigrateClaimsCommand extends BaseCommand {
    */
   protected initialize(): void {
     this.description('Migrate Tinlake reward claims from Centrifuge chain to a parachain')
+      // eslint-disable-next-line prettier/prettier
+      .option('-c, --config <filePath>', 'Path of a JSON/YAML configuration file (instead of using command-line options)')
       .requiredOption('-f, --from <wsUrl>', 'WebSocket URL of the source chain')
       .requiredOption('-t, --to <wsUrl>', 'WebSocket URL of the target parachain')
+      // eslint-disable-next-line prettier/prettier
       .requiredOption('-b, --block <number>', 'Number of the block which stored the latest claims root hash on the source chain')
       .addHelpText(
         'after',
@@ -43,6 +46,7 @@ export class MigrateClaimsCommand extends BaseCommand {
       )
       .action(() => {
         const options = this.opts();
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.execute(options.from as string, options.to as string, options.block as string);
       });
 //    .action(this.execute(this.opts().from, this.opts().to, this.opts().block).bind(this));
@@ -63,9 +67,8 @@ export class MigrateClaimsCommand extends BaseCommand {
    * @param {string} fromBlockNumber Number of the block where latest rootoptions List of options passed at command-line.
    */
   private async execute(fromUrl: string, toUrl: string, fromBlockNumber: string) {
-    console.log(
-      `Enter MigrateClaimsCommand.execute(fromUrl: ${fromUrl}, toUrl: ${toUrl}, fromBlockNumber: ${fromBlockNumber})`,
-    );
+    // eslint-disable-next-line prettier/prettier
+    console.log(`Enter MigrateClaimsCommand.execute(fromUrl: ${fromUrl}, toUrl: ${toUrl}, fromBlockNumber: ${fromBlockNumber})`);
 
     const controller = new ClaimsCommandController();
     await controller.connect(fromUrl, toUrl, PolkadotClient.SEED_ALICE);

--- a/packages/commands/claims/src/command.ts
+++ b/packages/commands/claims/src/command.ts
@@ -1,0 +1,51 @@
+import { BaseCommand } from '@centrifuge-commander/core/command';
+import { MigrateClaimsCommand } from './actions/migrate.js';
+
+/**
+ * Tinlake reward claims management command.
+ *
+ * This command is mainly used for migrating Tinlake reward claims from the standalone
+ * Centrifuge chain to a parachain such as Altair or running locally.
+ * 
+ * ## Usage
+ * This command is used as follows:
+ */
+export class ClaimsCommand extends BaseCommand {
+  private static readonly Name = 'claims';
+  private static readonly Description = 'Manage Tinlake reward claims (e.g. migration from Centriguge chain to a parachain)';
+
+  /**
+   * Builds a new chain command instance.
+   *
+   * @param {string} name A string containing the name of the command (default is 'chain').
+   */
+  constructor(name?: string) {
+    super(name === undefined ? ClaimsCommand.Name : name);
+  }
+
+  /**
+   * Handle command auto-completion.
+   */
+  public autocomplete(): void {
+    console.log('Claims command does not implement auto-completion for now');
+  }
+
+  /*
+   * Initialize the command options and arguments.
+   *
+   * This function builds command's actions (or subcommands) and bind
+   * them to this parent command.
+   * This protected method is invoked from the {BaseCommand} (super-class)
+   * constructor.
+   */
+  protected initialize(): void {
+    this.description(ClaimsCommand.Description)
+      .addHelpText(
+        'after',
+`
+Examples:
+  $ centrifuge claimsn migrate ...`,
+      )
+      .addCommand(new MigrateClaimsCommand());
+  }
+}

--- a/packages/commands/claims/src/command.ts
+++ b/packages/commands/claims/src/command.ts
@@ -6,7 +6,7 @@ import { MigrateClaimsCommand } from './actions/migrate.js';
  *
  * This command is mainly used for migrating Tinlake reward claims from the standalone
  * Centrifuge chain to a parachain such as Altair or running locally.
- * 
+ *
  * ## Usage
  * This command is used as follows:
  */
@@ -44,7 +44,7 @@ export class ClaimsCommand extends BaseCommand {
         'after',
 `
 Examples:
-  $ centrifuge claimsn migrate ...`,
+  $ centrifuge claims migrate ...`,
       )
       .addCommand(new MigrateClaimsCommand());
   }

--- a/packages/commands/claims/src/packages/client.ts
+++ b/packages/commands/claims/src/packages/client.ts
@@ -1,0 +1,103 @@
+import { ApiPromise, WsProvider } from "@polkadot/api";
+import { Keyring } from "@polkadot/keyring";
+import { KeyringPair } from "@polkadot/keyring/types";
+import chalk from 'chalk';
+
+/**
+ * Polkadot chain and parachain client class.
+ *
+ * This class helps setting up connections to the source chain and the target parachain.
+ */
+export class PolkadotClient {
+  public provider: WsProvider;
+  public api: ApiPromise;
+  private keyring: Keyring;
+
+  // Default seed accounts
+  public static SEED_ALICE = '//Alice';
+  public static SEED_BOB = '//Bob';
+
+  // Alice and Bob account addresses (for testing purpose)
+  public static ALICE_ADDRESS = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+  public static BOB_ADDRESS = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
+
+  /*
+   * Build a new instance of Polkadot client
+   *
+   * A new instance is created using 'create' method.
+   */
+  private constructor(provider: WsProvider, api: ApiPromise) {
+    this.api = api;
+    this.provider = provider;
+    this.keyring = new Keyring({ type: 'sr25519' });
+  }
+
+  /**
+   * Create a new client to access a chain or parachain using WebSocket connection.
+   *
+   * Would be better to put this code in the constructor. However constructors do not allow
+   * async methods to be invoked in their body.
+   *
+   * @param wsUrl Websocket URL to a chain or parachain (e.g. wss://localhost:9944)
+   * @returns An new Polkadot client instance is returned
+   */
+  static async connect(wsUrl: string): Promise<PolkadotClient> {
+    // Create connection provider
+    const provider = new WsProvider(wsUrl);
+
+    // Create API
+    const api = await ApiPromise.create({ provider });
+
+    return new PolkadotClient(provider, api);
+  }
+
+  /**
+   * Close Websocket connections to the source chain and target parachain.
+   */
+  async disconnect(): Promise<void> {
+    return this.api.disconnect();
+  }
+
+  /**
+   * Return keyring dictionary.
+   */
+  public getKeyring(): Keyring {
+    return this.keyring;
+  }
+
+  /**
+   * Create a new keyring pair from an hexadecimal or string seed.
+   *
+   * @param fromUri A URI of an account (e.g. '//Alice' or hex string)
+   * @see https://polkadot.js.org/docs/api/start/keyring
+   */
+  public addKeyringPair(seed: string): KeyringPair {
+    const keyringPair = this.keyring.addFromUri(seed);
+
+    // eslint-disable-next-line prettier/prettier
+    console.log(`  ... ${chalk.greenBright('✓')} added seed account ${chalk.blueBright(seed)} to keyring dictionary with address ${chalk.blueBright(keyringPair.address)}`);
+
+    return keyringPair;
+  }
+
+  /**
+   * Get a keyring pair given a key (e.g. '//Alice')
+   *
+   * @return A new [KeyringPair] is returned
+   */
+  public getKeyringPair(fromKey: string | Uint8Array): KeyringPair {
+    return this.keyring.getPair(fromKey);
+  }
+
+  /**
+   * Remove a pair from keyring dictionary.
+   *
+   * This method removes a given public key or address from the keyring dictionary.
+   *
+   * @param Input address or public key to be removed from the keyring dictionary.
+   */
+
+  public removeKeyringPair(fromKey: string | Uint8Array) {
+    this.keyring.removePair(fromKey);
+  }
+}

--- a/packages/commands/claims/src/packages/client.ts
+++ b/packages/commands/claims/src/packages/client.ts
@@ -17,9 +17,12 @@ export class PolkadotClient {
   public static SEED_ALICE = '//Alice';
   public static SEED_BOB = '//Bob';
 
-  // Alice and Bob account addresses (for testing purpose)
+  // Alice and Bob account addresses on Rococo relay chain (for testing purpose)
   public static ALICE_ADDRESS = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
   public static BOB_ADDRESS = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
+
+  // Alice address on parachain (for testing purpose)
+  public static PARACHAIN_ALICE_ADDRESS = 'kAMx1vYzEvumnpGcd6a5JL6RPE2oerbr6pZszKPFPZby2gLLF';
 
   /*
    * Build a new instance of Polkadot client
@@ -56,6 +59,14 @@ export class PolkadotClient {
    */
   async disconnect(): Promise<void> {
     return this.api.disconnect();
+  }
+
+  /**
+   * Return client Sudo key.
+   */
+  public async getSudoKey(): Promise<string> {
+    const key = await this.api.query.sudo.key();
+    return key.toString();
   }
 
   /**

--- a/packages/commands/claims/src/packages/controller.ts
+++ b/packages/commands/claims/src/packages/controller.ts
@@ -1,0 +1,249 @@
+/* eslint-disable prettier/prettier */
+//import { ApiPromise, WsProvider } from '@polkadot/api';
+import { Hash, BlockHash, SignedBlock } from '@polkadot/types/interfaces';
+import { PolkadotClient } from './client.js';
+import chalk from 'chalk';
+import { ApiPromise, Keyring, WsProvider } from '@polkadot/api';
+
+
+/**
+ * Reward claims migrator class.
+ *
+ * This class is used for extracting unclaimed rewards from Centrifuge chain to parachain.
+ */
+export class ClaimsCommandController {
+  private chainClient!: PolkadotClient;
+  private parachainClient!: PolkadotClient;
+
+  // Build a new reward claims controller
+  constructor() {
+    // nothing to do folks !!!
+  }
+
+  // Default chain and parachain endpoints
+  public static FULLNODE_CENTRIFUGE_CHAIN_URL = 'wss://fullnode-archive.centrifuge.io';
+  public static LOCAL_CENTRIFUGE_PARACHAIN_COLLATOR_URL = 'ws://127.0.0.1:9946';
+
+  // Name of the pallet (on Centrifuge chain) which process Tinlake reward claims
+  private static PALLET_CLAIMS = 'radClaims';
+  private static METHOD_STORE_ROOT_HASH = 'storeRootHash';
+
+  // --------------------------------------------------------------------------------------------
+  // Public methods
+  // --------------------------------------------------------------------------------------------
+
+  /**
+   * Open the connections to source chain and target parachain (eventually providing a seed account).
+   *
+   * Connections to the source chain and the target parachain are opened. An optional seed
+   * can be provided so that to set the keyring for later transactions on the parachain.
+   *
+   * @param fromUrl Websocket URL of the source chain (e.g. 'wss://fullnode-archive.centrifuge.io').
+   * @param toUrl   Websocket URL of the target parachain (collator node).
+   * @param seed    Seed account to be used to establish transactions with the target parachain (e.g. '//Alice').
+   */
+  async connect(fromUrl: string, toUrl: string, seed: string) {
+
+    // Open the connection to source chain
+    this.chainClient = await PolkadotClient.connect(fromUrl);
+
+    // Retrieve chain and node information
+    const [chain, chainNode] = await Promise.all([
+      this.chainClient.api.rpc.system.chain(),
+      this.chainClient.api.rpc.system.name(),
+    ]);
+
+    // eslint-disable-next-line prettier/prettier
+    console.log(`  ... ${chalk.greenBright('✓')} connected to chain '${chalk.blueBright(chain)}' on node '${chalk.blueBright(chainNode)}'`);
+
+    // Open a connection on the target parachain
+    this.parachainClient = await PolkadotClient.connect(toUrl);
+
+    // Retrieve parachain and parachain node information
+    const [collator, collatorNode] = await Promise.all([
+      this.parachainClient.api.rpc.system.chain(),
+      this.parachainClient.api.rpc.system.name(),
+    ]);
+
+    // eslint-disable-next-line prettier/prettier
+    console.log(`  ... ${chalk.greenBright('✓')} connected to parachain '${chalk.blueBright(collator)}' on node '${chalk.blueBright(collatorNode)}' with seed ${chalk.blueBright(seed)}`);
+
+    // Add a new keyring pair for the given raw seed to the keyring dictionary
+    const seedAccount = this.parachainClient.addKeyringPair(seed);
+
+    // Authenticates the current sudo key and sets the given seed account as the new Sudo
+    this.parachainClient.api.tx.sudo.setKey(seedAccount.address);
+
+    // Get the current sudo key in the system
+    const sudoKey = await this.parachainClient.api.query.sudo.key();
+    if (sudoKey.toString() === seedAccount.address) {
+      console.log(`  ... ${chalk.greenBright('✓')} parachain Sudo key set to account ${chalk.blueBright(seed)}`);
+    } else {
+      // eslint-disable-next-line prettier/prettier
+      console.log(`  >>> [${chalk.redBright('ERROR')}] cannot set parachain Sudo key to ${chalk.blueBright(seedAccount.address)}`);
+    }
+  }
+
+  // Close connections to source chain and target parachain
+  async disconnect() {
+    if (this.chainClient) await this.chainClient.disconnect();
+    if (this.parachainClient) await this.parachainClient.disconnect();
+  }
+
+  // Extract unclaimed rewards from a given root hash
+  //
+  // Command: node packages/cli/bin/run migration
+  //   wss://fullnode-archive.centrifuge.io
+  //   wss://fullnode-collator.charcoal.centrifuge.io
+  //   -b 6650470
+  //   --config /Users/frederik/.cfgCli/Migration/altair-migration.json
+  //   --creds /Users/frederik/.cfgCli/Migration/creds.json
+  //   --dry-run
+  // @param fromBlockNumber Number of the block where the latest call to 'radclaims(RootHashStored) was done.
+  async migrate(fromBlockNumber: string): Promise<void> {
+    if (!this.chainClient || !this.parachainClient) return;
+
+    console.log('');
+    console.log(`Call ${chalk.blueBright('ClaimsCommandController.migrate')} method`);
+    console.log('');
+
+    try {
+      // Extract block hash from the input block number
+      const blockHash: BlockHash = await this.chainClient.api.rpc.chain.getBlockHash(fromBlockNumber);
+      console.info(`  ... ${chalk.greenBright('✓')} checked input block number ${chalk.blueBright(fromBlockNumber)}`);
+//      console.info(`        > input block hash: ${chalk.blueBright(blockHash.toHex())}`);
+
+      // Get signed block
+      const signedBlock: SignedBlock = await this.chainClient.api.rpc.chain.getBlock(blockHash);
+
+      // Scan block's extrinsics so that to track the one triggering 'radclaims(store_root_hash)' action
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      signedBlock.block.extrinsics.forEach(async (extrinsic, _) => {
+        const {
+          method: { args, method, section },
+        } = extrinsic;
+
+        if (
+          section === ClaimsCommandController.PALLET_CLAIMS &&
+          method === ClaimsCommandController.METHOD_STORE_ROOT_HASH
+        ) {
+          // Get method's 'root_hash' parameter
+          const rootHashValue = args[0];
+
+          // eslint-disable-next-line prettier/prettier
+          console.info(`  ... ${chalk.greenBright('✓')} latest ${chalk.blueBright('radClaims(store_root_hash)')} root_hash value is ${chalk.blueBright(rootHashValue)}`);
+
+/*
+          console.log(`      > extrinsic id ${fromBlockNumber}-${index}`);
+          console.log(`        hash:        ${extrinsic.hash.toHex()}`);
+          console.log(`        tx pallet:   ${section}`);
+          console.log(`        tx method:   ${method}`);
+          console.log(`        tx roothash: ${rootHash.toString()}`);
+          console.log(`        meta:        ${meta.toString()}`);
+
+          console.log(`        ${section}.${method}(${args.map(a => a.toString()).join(', ')})`);
+          if (isSigned) {
+            console.log(`        signer:     ${extrinsic.signer.toString()}, nonce=${extrinsic.nonce.toString()}`);
+          }
+*/
+          // Migrate root hash (containing latest reward claims) to the target parachain
+          await this.migrateRootHash(rootHashValue as Hash);
+          await this.setBalance();
+        }
+      });
+    } catch (error) {
+      console.error(`Error`);
+    } finally {
+      console.log(`  ... rewards ${chalk.greenBright('successfully')} transferred to parachain`);
+    }
+  }
+
+  // --------------------------------------------------------------------------------------------
+  // Private methods
+  // --------------------------------------------------------------------------------------------
+
+  /*
+   * Migrate the given root hash to the target parachain.
+   *
+   * The root hash accumulates reward claims. Consequently, only the latest block which called
+   * the 'radClaims.storeRootHash(root_hash)' transaction must be taken into account to get the
+   * 'rootHash' value that is passed to this method.
+   * A Sudo transaction is used behind the scene.
+   *
+   * @param rootHash Latest root hash that is stored in 'radClaims'
+   */
+  private async migrateRootHash(rootHash: Hash): Promise<void> {
+    return;
+
+    if (this.parachainClient === undefined) return;
+
+    // Initialise the provider to connect to the local node
+    const provider = new WsProvider('ws://127.0.0.1:9944');
+
+    // Create the API and wait until ready (optional provider passed through)
+    const api = await ApiPromise.create({ provider });
+
+    const keyring = new Keyring({ type: 'sr25519' });
+    const keyringPair = keyring.addFromUri('//Alice');
+
+    // Retrieve the upgrade key from the chain state
+    //const sudoKey = await api.query.sudo.key();
+
+    // Get current sudo key in the system
+    //    const sudoKey = await this.parachainClient.api.query.sudo.key();
+
+    console.log(`  ... sudo key is ${keyringPair.address}`);
+
+    // Lookup from keyring (assuming we have added all, on --dev this would be `//Alice`)
+    // const sudoKeyAccount = this.parachainClient.getKeyringPair(sudoKey.toString());
+
+    // Create transaction for setting storage state
+    const transaction = api.tx.system.setStorage(rootHash);
+
+    // Perform actual storage transaction via the Sudo module
+    // eslint-disable-next-line prettier/prettier
+    const unsub = await api.tx.sudo
+      .sudo(transaction)
+      .signAndSend(keyringPair, ({ events = [], status }) => {
+        console.log(`Transaction status ${chalk.greenBright(status)}`);
+
+        if (status.isInBlock) {
+          console.error('You have just upgraded your chain');
+
+          console.log('Included at block hash', status.asInBlock.toHex());
+          console.log('Events:');
+
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+          console.log(JSON.stringify(events.toString(), null, 2));
+
+          // @ts-ignore
+          unsub();
+        }
+      })
+      .catch(err => console.log(err));
+  }
+
+  private async setBalance(): Promise<void> {
+    // Initialise the provider to connect to the local node
+    const provider = new WsProvider('ws://127.0.0.1:9944');
+
+    // Create the API and wait until ready (optional provider passed through)
+    const api = await ApiPromise.create({ provider });
+
+    const keyring = new Keyring({ type: 'sr25519' });
+    const keyringPair = keyring.addFromUri('//Alice');
+    
+    const transaction = api.tx.balances.setBalance(PolkadotClient.BOB_ADDRESS, 5000, 2000);
+
+    // eslint-disable-next-line prettier/prettier
+    const unsub = await api.tx.sudo
+      .sudo(transaction)
+      .signAndSend(keyringPair, ({ status, events }) => {
+        if (status.isInBlock || status.isFinalized) {
+          console.log(`Balance set successfully`);
+        }
+        unsub();
+    });
+  }
+}
+

--- a/packages/commands/claims/src/packages/index.ts
+++ b/packages/commands/claims/src/packages/index.ts
@@ -1,0 +1,2 @@
+export { PolkadotClient } from './client.js';
+export { ClaimsCommandController } from './controller.js';

--- a/packages/commands/claims/src/packages/storage.ts
+++ b/packages/commands/claims/src/packages/storage.ts
@@ -1,0 +1,7 @@
+// /// Total claimed amounts for all accounts.
+// #[pallet::storage]
+// #[pallet::getter(fn get_claimed_amount)]
+// pub(super) type ClaimedAmounts<T: Config> =
+//     StorageMap<_, Blake2_128Concat, T::AccountId, T::Balance, ValueQuery>;
+
+

--- a/packages/commands/claims/tests/claims.test.js
+++ b/packages/commands/claims/tests/claims.test.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const claims = require('..');
+
+describe('claims', () => {
+    it('needs tests');
+});

--- a/packages/commands/claims/tsconfig.json
+++ b/packages/commands/claims/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig.base.json",
+
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  
+  "references": [
+    { "path":  "../../libraries/core" }
+  ],
+
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/commands/crowdloan/package.json
+++ b/packages/commands/crowdloan/package.json
@@ -2,14 +2,17 @@
     "name": "@centrifuge-commander/crowdloan-command",
     "description": "Command used to manage Polkadot/Kusama crowdloan auctions for parachain slot acquisition or renewal",
     "version": "0.1.0",
-    "author": "Centrifuge Foundation <admin@centrifuge.io>",
-    "homepage": "https://github.com/centrifuge/centrifuge-commander#README.md",
-    "bugs": {"url": "https://github.com/centrifuge/centrifuge-commander/issues"},
+    "author": "Centrifuge Contributors <hello@centrifuge.io>",
+    "homepage": "https://github.com/centrifuge/commander#README.md",
+    "bugs": {"url": "https://github.com/centrifuge/commander/issues"},
     "license": "Apache-2.0",
     "keywords": [
+      "auction",
       "centrifuge",
-      "centrifuge-commander",
-      "chain-command"
+      "cli",
+      "commander",
+      "console",
+      "crowdloan-command"
     ],
     "type": "module",
     "main": "dist/index.js",
@@ -26,7 +29,7 @@
     "repository": {
       "type": "git",
       "directory": "packages/commands/crowdloan",
-      "url": "https://github.com/centrifuge/centrifuge-commander.git"
+      "url": "https://github.com/centrifuge/commander.git"
     },
     "engines": {
       "node": ">=14.17.4"

--- a/packages/commands/doctor/README.md
+++ b/packages/commands/doctor/README.md
@@ -1,3 +1,0 @@
-# Command `doctor`
-
-This command helps troubleshooting problems on a Centrifuge ecosystem.

--- a/packages/commands/setup/README.md
+++ b/packages/commands/setup/README.md
@@ -1,11 +1,11 @@
-# Centrifuge CLI `setup` Command
+# Centrifuge Commander Setup Command Module
 
-> TODO: description
+This command is used to configure the Centrifuge Commander. It is usually executed right after the commander's installation or to modify its configuration, such as, for instance, to change a repository or the language.
 
 ## Usage
 
 ```
-import { SetupCommand } from '@centrifuge-cli/setup-command';
+import { SetupCommand } from '@centrifuge-commander/setup-command';
 
 const command = new SetupCommand();
 

--- a/packages/commands/setup/package.json
+++ b/packages/commands/setup/package.json
@@ -43,9 +43,7 @@
     "pretest": "tsc -p test --noEmit",
     "posttest": "yarn lint",
     "test": "nyc --extension .ts mocha --forbid-only test/**/*.test.ts",
-    "prepack": "yarn build",
-    "postpack": "rm -f oclif.manifest.json",
-    "version": "oclif-dev readme && git add README.md"    
+    "prepack": "yarn build"
   },
   "dependencies": {
     "@centrifuge-commander/core": "^0.1.0",

--- a/packages/commands/setup/package.json
+++ b/packages/commands/setup/package.json
@@ -1,14 +1,16 @@
 {
-  "name": "@centrifuge-cli/setup-command",
-  "description": "Command used for setting up Centrifuge CLI's environment",
+  "name": "@centrifuge-commander/setup-command",
+  "description": "Command used for setting up Centrifuge Commander's environment",
   "version": "0.1.0",
-  "author": "Centrifuge Foundation <admin@centrifuge.io>",
-  "homepage": "https://github.com/centrifuge/centrifuge-cli#README.md",
-  "bugs": {"url": "https://github.com/centrifuge/centrifuge-cli/issues"},
+  "author": "Centrifuge Contributors <hello@centrifuge.io>",
+  "homepage": "https://github.com/centrifuge/commander#README.md",
+  "bugs": {"url": "https://github.com/centrifuge/commander/issues"},
   "license": "Apache-2.0",
   "keywords": [
     "centrifuge",
-    "centrifuge-cli",
+    "cli",
+    "commander",
+    "console",
     "setup-command"
   ],
   "type": "module",
@@ -27,7 +29,7 @@
   "repository": {
     "type": "git",
     "directory": "packages/commands/setup",
-    "url": "https://github.com/centrifuge/centrifuge-cli.git"
+    "url": "https://github.com/centrifuge/commander.git"
   },
   "engines": {
     "node": ">=14.17.4"
@@ -46,7 +48,7 @@
     "version": "oclif-dev readme && git add README.md"    
   },
   "dependencies": {
-    "@centrifuge-cli/core": "^0.1.0",
+    "@centrifuge-commander/core": "^0.1.0",
     "cli-ux": "^5.6.0",
     "commander": "^8.3.0"
   },

--- a/packages/commands/setup/src/actions/show.ts
+++ b/packages/commands/setup/src/actions/show.ts
@@ -1,4 +1,4 @@
-import { BaseCommand } from '@centrifuge-cli/core/command';
+import { BaseCommand } from '@centrifuge-commander/core/command';
 
 /*
  * Show setup command options.

--- a/packages/commands/setup/src/command.ts
+++ b/packages/commands/setup/src/command.ts
@@ -1,4 +1,4 @@
-import { BaseCommand } from '@centrifuge-cli/core/command';
+import { BaseCommand } from '@centrifuge-commander/core/command';
 import { SetupShowCommand } from './actions/show.js';
 
 /**

--- a/packages/libraries/core/package.json
+++ b/packages/libraries/core/package.json
@@ -1,15 +1,17 @@
 {
-    "name": "@centrifuge-cli/core",
+    "name": "@centrifuge-commander/core",
     "description": "Common helper functions used for implementing Centrifuge CLI",
     "version": "0.1.0",
-    "author": "Centrifuge Foundation <admin@centrifuge.io>",
-    "homepage": "https://github.com/centrifuge/centrifuge-cli#README.md",
-    "bugs": {"url": "https://github.com/centrifuge/centrifuge-cli/issues"},
+    "author": "Centrifuge Contributors <hello@centrifuge.io>",
+    "homepage": "https://github.com/centrifuge/commander#README.md",
+    "bugs": {"url": "https://github.com/centrifuge/commander/issues"},
     "license": "Apache-2.0",
     "keywords": [
       "centrifuge",
-      "centrifuge-cli",
-      "core-library"
+      "cli",
+      "commander",
+      "core-library",
+      "library"
     ],
     "type": "module",
     "main": "dist/index.js",
@@ -31,7 +33,7 @@
     "repository": {
       "type": "git",
       "directory": "packages/libraries/core",
-      "url": "https://github.com/centrifuge/centrifuge-cli.git"
+      "url": "https://github.com/centrifuge/commander.git"
     },
     "engines": {
       "node": ">=14.17.4"
@@ -48,11 +50,11 @@
       "prepack": "yarn build"
     },
     "dependencies": {
-      "@aws-sdk/client-ec2": "^3.44.0",
-      "ajv": "^8.8.0",
+      "@aws-sdk/client-ec2": "^3.49.0",
+      "ajv": "^8.10.0",
       "ansi-styles": "^6.1.0",
       "chalk": "^5.0.0",
-      "commander": "^8.3.0",
+      "commander": "^9.0.0",
       "ini": "^2.0.0",
       "strip-ansi": "^7.0.0",
       "supports-color": "^9.2.0",
@@ -61,8 +63,8 @@
     "devDependencies": {
       "@types/chai": "^4.3.0",
       "@types/ini": "^1.3.31",
-      "@types/mocha": "^9.0.0",
-      "@types/node": "^16.11.0",
+      "@types/mocha": "^9.1.0",
+      "@types/node": "^17.0.0",
       "@types/supports-color": "^8.1.0",
       "chai": "^4.3.0",
       "fancy-test": "^2.0.0",

--- a/packages/libraries/core/package.json
+++ b/packages/libraries/core/package.json
@@ -18,6 +18,7 @@
     "exports": {
         "./command": "./dist/command.js",
         "./colors": "./dist/colors.js",
+        "./crypto": "./dist/crypto/index.js",
         "./decorators": "./dist/decorators/index.js",
         "./interfaces": "./dist/interfaces/index.js",
         "./utilities": "./dist/utilities.js",

--- a/packages/libraries/core/src/crypto/index.ts
+++ b/packages/libraries/core/src/crypto/index.ts
@@ -1,0 +1,67 @@
+import { xxhashAsHex, blake2AsHex } from '@polkadot/util-crypto';
+
+// export enum HasherFunction {
+//   None,
+//   Twox64,
+//   Twox64Concat,
+//   Twox128,
+//   Twox256,
+//   Blake2_128,
+//   Blake2_128Concat,
+//   Blake2_256
+// }
+
+export interface Hasher {
+  hash(input: string | Uint8Array): string;
+}
+
+export class Twox128Hasher implements Hasher {
+  public hash(input: string | Uint8Array): string {
+    /* Note:
+     * We use XXHash to output a 128 bit hash. However, XXHash only supports 32 bit and 64 bit outputs. 
+     * To correctly generate the 128 bit hash, we need to hash the same phrase twice, with seed 0 and seed 1, 
+     * and concatenate them.
+     */
+    return xxhashAsHex(input, 128).slice(2);
+  }
+}
+
+export class Twox256Hasher implements Hasher {
+  public hash(input: string | Uint8Array): string {
+    return xxhashAsHex(input, 256).slice(2);
+  }
+}
+
+export class Blake2_128Hasher implements Hasher {
+  public hash(input: string | Uint8Array): string {
+    return blake2AsHex(input, 128).slice(2);
+  }
+}
+
+export class Blake2_256Hasher implements Hasher {
+  public hash(input: string | Uint8Array): string {
+    return blake2AsHex(input, 256).slice(2);
+  }
+}
+
+    // static async hash(input: string | Uint8Array, function: Function): Promise<string> {
+    //     if (hasher === Hasher.None){
+    //         return await hexEncode(input);
+    //     } else if(hasher === Hasher.Twox64) {
+    //         return xxhashAsHex(input, 64).slice(2);
+    //     } else if (hasher === Hasher.Twox64Concat) {
+    //         return xxhashAsHex(input, 64).slice(2) + await hexEncode(input);
+    //     } else if (hasher === Hasher.Twox128) {
+    //         return xxhashAsHex(input, 128).slice(2);
+    //     } else if (hasher === Hasher.Twox256) {
+    //         return xxhashAsHex(input, 256).slice(2);
+    //     } else if (hasher === Hasher.Blake2_128) {
+    //         return blake2AsHex(input, 128).slice(2);
+    //     } else if (hasher === Hasher.Blake2_128Concat) {
+    //         return blake2AsHex(input, 128).slice(2) + await hexEncode(input);
+    //     } else if (hasher === Hasher.Blake2_256) {
+    //         return blake2AsHex(input, 256).slice(2);
+    //     } else {
+    //         return Promise.reject("Unreachable code");
+    //     }
+    // }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
 
     // Commands
     { "path": "./packages/commands/chain" },
+    { "path": "./packages/commands/claims" },
     { "path": "./packages/commands/setup" },
     { "path": "./packages/commands/crowdloan" }
   ]


### PR DESCRIPTION
## Objectives
This PR implements a new command for Centrifuge Commander which aims at:
- [x] Extracting a root hash containing accumulated claims from the standalone Centrifuge chain. For doing so, the user provides the latest block in the standalone Centrifuge chain, that triggered a `radClaims.setRootHash(root_hash)` transaction. Note that the aim of this command is to make the transfer of reward claims after the standalone Centrifuge chain was stopped (see https://centrifuge.hackmd.io/HpGW0J6TRo25splXkuH9TA?both for more information on how the state of the standalone Centrifuge chain will be migrated to a Centrifuge parachain. 
- [ ] Migrate (or store) the extracted root hash to the Centrifuge parachain, by means of a Sudo call to the `System.setStorage(items)` extrinsic.
- [ ] Implement tests for storage integrity checking after the migration was done.